### PR TITLE
bagfix: None checks

### DIFF
--- a/odetam/model.py
+++ b/odetam/model.py
@@ -38,7 +38,7 @@ def handle_db_property(cls, deta_class):
 class DetaModelMetaClass(pydantic.main.ModelMetaclass):
     def __new__(mcs, name, bases, dct):
         cls = super().__new__(mcs, name, bases, dct)
-        if getattr(cls.Config, "table_name", None):
+        if getattr(cls.Config, "table_name", None) is not None:
             cls.__db_name__ = cls.Config.table_name
         else:
             cls.__db_name__ = re.sub(r"(?<!^)(?=[A-Z])", "_", name).lower()
@@ -68,7 +68,7 @@ class BaseDetaModel(BaseModel):
                 continue
             if field_name in exclude:
                 continue
-            if not getattr(self, field_name, None):
+            if getattr(self, field_name, None) is None:
                 as_dict[field_name] = None
                 continue
             if field.type_ in DETA_TYPES:
@@ -91,7 +91,7 @@ class BaseDetaModel(BaseModel):
     def _deserialize(cls, data):
         as_dict = {}
         for field_name, field in cls.__fields__.items():
-            if not data.get(field_name):
+            if data.get(field_name) is None:
                 continue
             if field.type_ in DETA_TYPES:
                 as_dict[field_name] = data[field_name]


### PR DESCRIPTION
In some "if" statements None was checking via simple boolean check like "if not data.get("key"):". 
But for False values and empty containers this statement also returns true, and wrong code was executed, so that values transfered to database as null.