### PR TITLE
Add missed types

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,31 +4,33 @@ on: [push, pull_request]
 
 jobs:
   build:
-    runs-on: ${{matrix.platform}}
-
     strategy:
       matrix:
         platform: [ubuntu-latest, macos-latest]
         version: [3.7, 3.8, 3.9, "3.10", 3.11]
 
-    steps:
-      - uses: actions/checkout@v2
+    runs-on: ${{ matrix.platform }}
 
-      - name: Setup Python
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Set up Python
         uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.version }}
 
-      - name: Install poetry
-        uses: abatilo/actions-poetry@v2.0.0
+      - name: Install Poetry
+        run: |
+          pip install poetry
+          poetry config virtualenvs.create false  # Disable virtualenv creation
 
-      - name: Poetry install
+      - name: Install dependencies
         run: poetry install
 
-      - name: run tests
+      - name: Run tests
         env:
           INTEGRATION_TEST_KEY: ${{ secrets.INTEGRATION_TEST_KEY }}
         run: poetry run pytest --cov=odetam
 
       - uses: codecov/codecov-action@v2
-

--- a/odetam/async_model.py
+++ b/odetam/async_model.py
@@ -1,8 +1,7 @@
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, List, Optional, Type, TypeVar, Union
 
 from deta import AsyncBase, Deta
 from deta.base import FetchResponse
-from typing_extensions import Self
 
 from odetam.exceptions import DetaError, InvalidKey, ItemNotFound
 from odetam.model import BaseDetaModel, DetaModelMetaClass, handle_db_property
@@ -19,9 +18,12 @@ class AsyncDetaModelMetaClass(DetaModelMetaClass):
         return handle_db_property(cls, AsyncBase)
 
 
+T = TypeVar("T", bound="AsyncDetaModel")
+
+
 class AsyncDetaModel(BaseDetaModel, metaclass=AsyncDetaModelMetaClass):
     @classmethod
-    async def get(cls, key: str) -> Self:
+    async def get(cls: Type[T], key: str) -> T:
         """
         Get a single instance
         :param key: Deta database key
@@ -36,7 +38,7 @@ class AsyncDetaModel(BaseDetaModel, metaclass=AsyncDetaModelMetaClass):
         return cls._return_item_or_raise(item)
 
     @classmethod
-    async def get_or_none(cls, key: str) -> Optional[Self]:
+    async def get_or_none(cls: Type[T], key: str) -> Optional[T]:
         """Try to get item by key or return None if item not found"""
         try:
             return await cls.get(key)
@@ -44,7 +46,7 @@ class AsyncDetaModel(BaseDetaModel, metaclass=AsyncDetaModelMetaClass):
             return None
 
     @classmethod
-    async def get_all(cls) -> List[Self]:
+    async def get_all(cls: Type[T]) -> List[T]:
         """Get all the records from the database"""
         response: FetchResponse = await cls.__db__.fetch()
         records: List[Dict[str, Any]] = response.items
@@ -56,8 +58,8 @@ class AsyncDetaModel(BaseDetaModel, metaclass=AsyncDetaModelMetaClass):
 
     @classmethod
     async def query(
-        cls, query_statement: Union[DetaQuery, DetaQueryStatement, DetaQueryList]
-    ) -> List[Self]:
+        cls: Type[T], query_statement: Union[DetaQuery, DetaQueryStatement, DetaQueryList]
+    ) -> List[T]:
         """Get items from database based on the query."""
         response: FetchResponse = await cls.__db__.fetch(query_statement.as_query())
         records: List[Dict[str, Any]] = response.items
@@ -75,7 +77,7 @@ class AsyncDetaModel(BaseDetaModel, metaclass=AsyncDetaModelMetaClass):
         await cls.__db__.delete(key)
 
     @classmethod
-    async def put_many(cls, items: List[Self]) -> List[Self]:
+    async def put_many(cls: Type[T], items: List[T]) -> List[T]:
         """Put multiple instances at once
 
         :param items: List of pydantic objects to put in the database

--- a/odetam/async_model.py
+++ b/odetam/async_model.py
@@ -70,12 +70,12 @@ class AsyncDetaModel(BaseDetaModel, metaclass=AsyncDetaModelMetaClass):
         return [cls._deserialize(item) for item in records]
 
     @classmethod
-    async def delete_key(cls, key: str):
+    async def delete_key(cls, key: str) -> None:
         """Delete an item based on the key"""
         await cls.__db__.delete(key)
 
     @classmethod
-    async def put_many(cls, items: List[Self]):
+    async def put_many(cls, items: List[Self]) -> List[Self]:
         """Put multiple instances at once
 
         :param items: List of pydantic objects to put in the database
@@ -103,7 +103,7 @@ class AsyncDetaModel(BaseDetaModel, metaclass=AsyncDetaModelMetaClass):
     async def _db_put(cls, data: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
         return await cls.__db__.put(data)
 
-    async def save(self):
+    async def save(self) -> None:
         """Saves the record to the database. Behaves as upsert, will create
         if not present. Database key will then be set on the object."""
         # exclude = set()
@@ -114,7 +114,7 @@ class AsyncDetaModel(BaseDetaModel, metaclass=AsyncDetaModelMetaClass):
         saved = await self._db_put(self._serialize())
         self.key = saved["key"]
 
-    async def delete(self):
+    async def delete(self) -> None:
         """Delete the open object from the database. The object will still exist in
         python, but will be deleted from the database and the key attribute will be
         set to None."""

--- a/odetam/model.py
+++ b/odetam/model.py
@@ -178,7 +178,7 @@ class DetaModel(BaseDetaModel, metaclass=DetaModelMetaClass):
         return [cls._deserialize(item) for item in records]
 
     @classmethod
-    def delete_key(cls, key: str):
+    def delete_key(cls, key: str) -> None:
         """Delete an item based on the key"""
         cls.__db__.delete(key)
 
@@ -211,7 +211,7 @@ class DetaModel(BaseDetaModel, metaclass=DetaModelMetaClass):
     def _db_put(cls, data: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
         return cls.__db__.put(data)  # type: ignore
 
-    def save(self):
+    def save(self) -> None:
         """Saves the record to the database. Behaves as upsert, will create
         if not present. Database key will then be set on the object."""
         # exclude = set()
@@ -222,7 +222,7 @@ class DetaModel(BaseDetaModel, metaclass=DetaModelMetaClass):
         saved = self._db_put(self._serialize())
         self.key = saved["key"]
 
-    def delete(self):
+    def delete(self) -> None:
         """Delete the open object from the database. The object will still exist in
         python, but will be deleted from the database and the key attribute will be
         set to None."""


### PR DESCRIPTION
Add missed types for `delete_key`, `delete` and `save` methods.
They all return just `None`, but linters still show warnings for these methods occasionally.